### PR TITLE
Add option to specify MSK cluster configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,41 @@ Module usage:
        cidr_blocks            = ["${values(var.compute_cidrs)}"]
      }
 
+     module "msk_cluster_with_config" {
+       source = "git::https://github.com/UKHomeOffice/acp-tf-msk-cluster?ref=master"
+
+       name                   = "msktestclusterwithconfig"
+       msk_instance_type      = "kafka.m5.large"
+       kafka_version          = "1.1.1"
+       environment            = "${var.environment}"
+       number_of_broker_nodes = "3"
+       subnet_ids             = ["${data.aws_subnet_ids.suben_id_name.ids}"]
+       vpc_id                 = "${var.vpc_id}"
+       ebs_volume_size        = "50"
+       cidr_blocks            = ["${values(var.compute_cidrs)}"]
+
+       config_name           = "testmskconfig"
+       config_kafka_versions = ["1.1.1"]
+       config_description    = "Test MSK configuration"
+
+       config_server_properties = <<PROPERTIES
+     auto.create.topics.enable = true
+     delete.topic.enable = true
+     PROPERTIES
+     }
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | cidr\_blocks | MSK cluster cidr blocks | list | `<list>` | no |
 | client\_broker | Encryption setting for data in transit between clients and brokers. Valid values: TLS, TLS_PLAINTEXT, and PLAINTEXT | string | `"TLS_PLAINTEXT"` | no |
+| config\_arn | ARN of the MSK configuration to attach to the MSK cluster | string | `""` | no |
+| config\_description | The description of the MSK configuration | string | `""` | no |
+| config\_kafka\_versions | A list of Kafka versions that the configuration supports | list | `<list>` | no |
+| config\_name | Name of the MSK configuration to attach to the MSK cluster | string | `""` | no |
+| config\_revision | The revision of the MSK configuration to use | string | `""` | no |
+| config\_server\_properties | The properties to set on the MSK cluster. Omitted properties are set to a default value | string | `""` | no |
 | ebs\_volume\_size | The msk custer EBS volume size | string | n/a | yes |
 | environment | The environment the msk cluster is running in i.e. dev, prod etc | string | n/a | yes |
 | kafka\_version | The kafka version for the AWS MSK cluster | string | `"2.2.1"` | no |

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,28 @@
 *        cidr_blocks            = ["${values(var.compute_cidrs)}"]
 *      }
 *
+*      module "msk_cluster_with_config" {
+*        source = "git::https://github.com/UKHomeOffice/acp-tf-msk-cluster?ref=master"
+*
+*        name                   = "msktestclusterwithconfig"
+*        msk_instance_type      = "kafka.m5.large"
+*        kafka_version          = "1.1.1"
+*        environment            = "${var.environment}"
+*        number_of_broker_nodes = "3"
+*        subnet_ids             = ["${data.aws_subnet_ids.suben_id_name.ids}"]
+*        vpc_id                 = "${var.vpc_id}"
+*        ebs_volume_size        = "50"
+*        cidr_blocks            = ["${values(var.compute_cidrs)}"]
+*
+*        config_name           = "testmskconfig"
+*        config_kafka_versions = ["1.1.1"]
+*        config_description    = "Test MSK configuration"
+*
+*        config_server_properties = <<PROPERTIES
+*      auto.create.topics.enable = true
+*      delete.topic.enable = true
+*      PROPERTIES
+*      }
 *
 *
  */
@@ -69,6 +91,8 @@ resource "aws_kms_alias" "msk_cluster_kms_alias" {
 }
 
 resource "aws_msk_cluster" "msk_kafka" {
+  count = "${var.config_name == "" && var.config_arn == ""  ? 1 : 0}"
+
   cluster_name           = "${var.name}"
   kafka_version          = "${var.kafka_version}"
   number_of_broker_nodes = "${var.number_of_broker_nodes}"
@@ -89,4 +113,44 @@ resource "aws_msk_cluster" "msk_kafka" {
   }
 
   tags = "${merge(var.tags, map("Name", format("%s-%s", var.environment, var.name)), map("Env", var.environment))}"
+}
+
+resource "aws_msk_cluster" "msk_kafka_with_config" {
+  count = "${var.config_name != "" || var.config_arn != ""  ? 1 : 0}"
+
+  cluster_name           = "${var.name}"
+  kafka_version          = "${var.kafka_version}"
+  number_of_broker_nodes = "${var.number_of_broker_nodes}"
+
+  broker_node_group_info {
+    instance_type   = "${var.msk_instance_type}"
+    ebs_volume_size = "${var.ebs_volume_size}"
+    client_subnets  = ["${var.subnet_ids}"]
+    security_groups = ["${aws_security_group.sg_msk.id}"]
+  }
+
+  encryption_info {
+    encryption_at_rest_kms_key_arn = "${aws_kms_key.kms.arn}"
+
+    encryption_in_transit {
+      client_broker = "${var.client_broker}"
+    }
+  }
+
+  configuration_info {
+    arn      = "${coalesce(var.config_arn, join("", aws_msk_configuration.msk_kafka_config.*.arn))}"
+    revision = "${coalesce(var.config_revision, join("", aws_msk_configuration.msk_kafka_config.*.latest_revision))}"
+  }
+
+  tags = "${merge(var.tags, map("Name", format("%s-%s", var.environment, var.name)), map("Env", var.environment))}"
+}
+
+resource "aws_msk_configuration" "msk_kafka_config" {
+  count = "${var.config_name != "" && var.config_arn == "" ? 1 : 0}"
+
+  kafka_versions = "${var.config_kafka_versions}"
+  name           = "${var.config_name}"
+  description    = "${var.config_description}"
+
+  server_properties = "${var.config_server_properties}"
 }

--- a/output.tf
+++ b/output.tf
@@ -1,19 +1,19 @@
 output "zookeeper_connect_string" {
   description = "A comma separated list of one or more IP:port pairs to use to connect to the Apache Zookeeper cluster"
-  value       = "${aws_msk_cluster.msk_kafka.zookeeper_connect_string}"
+  value       = "${coalesce(element(concat(aws_msk_cluster.msk_kafka.*.zookeeper_connect_string, list("")), 0), element(concat(aws_msk_cluster.msk_kafka_with_config.*.zookeeper_connect_string, list("")), 0))}"
 }
 
 output "bootstrap_brokers" {
   description = "Plaintext connection host:port pairs"
-  value       = "${aws_msk_cluster.msk_kafka.bootstrap_brokers}"
+  value       = "${coalesce(element(concat(aws_msk_cluster.msk_kafka.*.bootstrap_brokers, list("")), 0), element(concat(aws_msk_cluster.msk_kafka_with_config.*.bootstrap_brokers, list("")), 0))}"
 }
 
 output "bootstrap_brokers_tls" {
   description = "TLS connection host:port pairs"
-  value       = "${aws_msk_cluster.msk_kafka.bootstrap_brokers_tls}"
+  value       = "${coalesce(element(concat(aws_msk_cluster.msk_kafka.*.bootstrap_brokers_tls, list("")), 0), element(concat(aws_msk_cluster.msk_kafka_with_config.*.bootstrap_brokers_tls, list("")), 0))}"
 }
 
 output "msk_cluster_arn" {
   description = "The MSK cluster arn"
-  value       = "${element(concat(aws_msk_cluster.msk_kafka.*.arn, list("")), 0)}"
+  value       = "${coalesce(element(concat(aws_msk_cluster.msk_kafka.*.arn, list("")), 0), element(concat(aws_msk_cluster.msk_kafka_with_config.*.arn, list("")), 0))}"
 }

--- a/variable.tf
+++ b/variable.tf
@@ -46,3 +46,34 @@ variable "client_broker" {
   description = "Encryption setting for data in transit between clients and brokers. Valid values: TLS, TLS_PLAINTEXT, and PLAINTEXT"
   default     = "TLS_PLAINTEXT"
 }
+
+variable "config_name" {
+  description = "Name of the MSK configuration to attach to the MSK cluster"
+  default     = ""
+}
+
+variable "config_kafka_versions" {
+  description = "A list of Kafka versions that the configuration supports"
+  default     = []
+}
+
+variable "config_server_properties" {
+  description = "The properties to set on the MSK cluster. Omitted properties are set to a default value"
+  default     = ""
+}
+
+variable "config_description" {
+  description = "The description of the MSK configuration"
+  default     = ""
+}
+
+variable "config_revision" {
+  description = "The revision of the MSK configuration to use"
+  default     = ""
+}
+
+# to be used if a configuration exists already
+variable "config_arn" {
+  description = "ARN of the MSK configuration to attach to the MSK cluster"
+  default     = ""
+}


### PR DESCRIPTION
Notes:
- AWS does not currently allow you to delete MSK cluster configurations yet (neither through the console, CLI or API), so by extension Terraform also does not let you do this. The configuration will simply be removed from Terraform's state.
- AWS does not currently allow you to edit MSK cluster configurations once they have been created so if any changes need to be made to a config, you will need to alter the name of the config so that a completely new one is created.
- This implementation allows a user to have a custom config created with the cluster, or provide the ARN and revision for an existing config.

Testing done:
- Added a new MSK cluster with a new custom config (successful)
- Updated config of an MSK cluster after the config's creation via this repo (failed as AWS does not support this yet, see above)
- Added an existing config to an existing cluster (successful, but will re-create the MSK cluster as it is a different resource)