### PR TITLE
Value type and bootstrap brokers output fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,7 @@ resource "aws_msk_cluster" "msk_kafka" {
 
   client_authentication {
     tls {
-      certificate_authority_arns = aws_acmpca_certificate_authority.msk_kafka_with_ca[count.index].arn
+      certificate_authority_arns = [aws_acmpca_certificate_authority.msk_kafka_with_ca[count.index].arn]
     }
   }
 
@@ -170,7 +170,7 @@ resource "aws_msk_cluster" "msk_kafka_with_config" {
 
   client_authentication {
     tls {
-      certificate_authority_arns = aws_acmpca_certificate_authority.msk_kafka_ca_with_config[count.index].arn
+      certificate_authority_arns = [aws_acmpca_certificate_authority.msk_kafka_ca_with_config[count.index].arn]
     }
   }
 
@@ -304,6 +304,6 @@ EOF
 resource "aws_iam_policy_attachment" "msk_acmpca_iam_policy_attachment" {
   count      = var.certificateauthority == "true" ? 1 : 0
   name       = "${var.name}-acmpcaPolicy-attachment"
-  users      = aws_iam_user.msk_acmpca_iam_user[count.index].name
+  users      = [aws_iam_user.msk_acmpca_iam_user[count.index].name]
   policy_arn = aws_iam_policy.acmpca_policy_with_msk_policy[count.index].arn
 }

--- a/output.tf
+++ b/output.tf
@@ -5,7 +5,7 @@ output "zookeeper_connect_string" {
 
 output "bootstrap_brokers" {
   description = "Plaintext connection host:port pairs"
-  value       = "${coalesce(element(concat(aws_msk_cluster.msk_kafka.*.bootstrap_brokers, list("")), 0), element(concat(aws_msk_cluster.msk_kafka_with_config.*.bootstrap_brokers, list("")), 0))}"
+  value       = "${join("", [element(concat(aws_msk_cluster.msk_kafka.*.bootstrap_brokers, list("")), 0), element(concat(aws_msk_cluster.msk_kafka_with_config.*.bootstrap_brokers, list("")), 0)])}"
 }
 
 output "bootstrap_brokers_tls" {


### PR DESCRIPTION
https://github.com/UKHomeOffice/acp-tf-msk-cluster/commit/48574de147fb817449f66ecc12151eb805f5ae43 fixes the `certificate_authority_arns` and `users` values having the incorrect types

https://github.com/UKHomeOffice/acp-tf-msk-cluster/commit/0da6d706ca7f0bc031dc2d301d441034b766dbce fixes the `coalesce` on the `bootstrap_brokers` output not working when `client_broker` is not set to either `TLS_PLAINTEXT` or `PLAINTEXT` (`bootstrap_brokers` is only a valid attribute for the cluster when one of those two values is used - https://www.terraform.io/docs/providers/aws/r/msk_cluster.html#bootstrap_brokers)