### PR TITLE
Adding security group record for TLS for zookeeper broker nodes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,13 @@ resource "aws_security_group" "sg_msk" {
   }
 
   ingress {
+    from_port   = 2182
+    to_port     = 2182
+    protocol    = "tcp"
+    cidr_blocks = var.cidr_blocks
+  }
+
+  ingress {
     from_port   = 9092
     to_port     = 9092
     protocol    = "tcp"


### PR DESCRIPTION
Due to a new update starting from Kafka version 2.5.1 you can use TLS security for encryption in transit between your clients and your Apache ZooKeeper nodes. This required us to open a new port within the security group.

