### PR TITLE
ACPENG-2357: Revert aws provider to 3.0 and add lifecycle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,6 +128,12 @@ resource "aws_msk_cluster" "msk_kafka" {
     security_groups = [aws_security_group.sg_msk.id]
   }
 
+  lifecycle {
+    ignore_changes = [
+      client_authentication["sasl"],
+    ]
+  }
+
   client_authentication {
     tls {
       certificate_authority_arns = length(var.ca_arn) != 0 ? var.ca_arn : [aws_acmpca_certificate_authority.msk_kafka_with_ca[count.index].arn]

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.5"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 1.0"


### PR DESCRIPTION
Revert aws provider to 3.0 and add lifecycle